### PR TITLE
Feature/add rtoken support

### DIFF
--- a/contracts/PaymentProcessor.sol
+++ b/contracts/PaymentProcessor.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.0;
 
-import { Ownable } from 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
+import { Ownable } from '@openzeppelin/contracts/ownership/Ownable.sol';
 import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import { UniswapExchangeInterface } from '../uniswap/contracts/UniswapExchangeInterface.sol';
 import { UniswapFactoryInterface } from '../uniswap/contracts/UniswapFactoryInterface.sol';
@@ -195,12 +195,3 @@ contract PaymentProcessor is Ownable {
 
     function() external payable { }
 }
-
-// for testing
-import { ERC20Mintable } from "openzeppelin-solidity/contracts/token/ERC20/ERC20Mintable.sol";
-import { ComptrollerMock } from "@rtoken/contracts/contracts/test/ComptrollerMock.sol";
-import { InterestRateModelMock } from "@rtoken/contracts/contracts/test/InterestRateModelMock.sol";
-import { CErc20 } from "@rtoken/contracts/compound/contracts/CErc20.sol";
-import { CompoundAllocationStrategy } from "@rtoken/contracts/contracts/CompoundAllocationStrategy.sol";
-import { RToken } from "@rtoken/contracts/contracts/RToken.sol";
-import { Proxy } from "@rtoken/contracts/contracts/Proxy.sol";

--- a/contracts/PaymentProcessor.sol
+++ b/contracts/PaymentProcessor.sol
@@ -1,9 +1,10 @@
 pragma solidity ^0.5.0;
 
 import { Ownable } from 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
-import { IERC20 } from 'openzeppelin-solidity/contracts/token/ERC20/IERC20.sol';
+import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import { UniswapExchangeInterface } from '../uniswap/contracts/UniswapExchangeInterface.sol';
 import { UniswapFactoryInterface } from '../uniswap/contracts/UniswapFactoryInterface.sol';
+import { IRToken } from '@rtoken/contracts/contracts/IRToken.sol';
 
 contract PaymentProcessor is Ownable {
     uint256 constant UINT256_MAX = ~uint256(0);
@@ -13,6 +14,8 @@ contract PaymentProcessor is Ownable {
     UniswapFactoryInterface public uniswapFactory;
     address public intermediaryToken;
     UniswapExchangeInterface public intermediaryTokenExchange;
+
+    bool public isIntermediaryRToken;
 
     constructor(UniswapFactoryInterface uniswapFactory_)
         public {
@@ -46,10 +49,34 @@ contract PaymentProcessor is Ownable {
     function setIntermediaryToken(address token)
         onlyOwner
         external {
+        isIntermediaryRToken = false;
         intermediaryToken = token;
         if (token != address(0)) {
             intermediaryTokenExchange = UniswapExchangeInterface(uniswapFactory.getExchange(token));
             require(address(intermediaryTokenExchange) != address(0), "The token does not have an exchange");
+        } else {
+            intermediaryTokenExchange = UniswapExchangeInterface(address(0));
+        }
+    }
+
+    /**
+     * Since there isn't a efficient way to check if
+     * the token really is an RToken, we assume that it is
+     * It is in the best interests of the owner to supply
+     * a correct RToken address, otherwise they cannot collect payments
+     */
+    function setIntermediaryRToken(address token)
+        onlyOwner
+        external {
+        isIntermediaryRToken = true;
+        intermediaryToken = token;
+        if (token != address(0)) {
+            IRToken rToken = IRToken(token);
+            address underlying = address(rToken.token());
+            require (underlying != address(0), "No underlying token for rToken");
+            //this will infact represent the underlying token's exchange, since the RToken itself does not need one
+            intermediaryTokenExchange = UniswapExchangeInterface(uniswapFactory.getExchange(underlying));
+            require(address(intermediaryTokenExchange) != address(0), "The underlying token does not have an exchange");
         } else {
             intermediaryTokenExchange = UniswapExchangeInterface(address(0));
         }
@@ -64,6 +91,13 @@ contract PaymentProcessor is Ownable {
             amountBought = intermediaryTokenExchange.ethToTokenSwapInput.value(msg.value)(
                 1 /* min_tokens */,
                 UINT256_MAX /* deadline */);
+            if (isIntermediaryRToken) {
+                IRToken rToken = IRToken(intermediaryToken);
+                IERC20 underlying = IERC20(rToken.token());
+                require (address(underlying) != address(0), "No underlying token for rToken");
+                underlying.approve(address(rToken), amountBought);
+                rToken.mint(amountBought);
+            }
         }
         emit EtherDepositReceived(orderId, msg.sender, msg.value, intermediaryToken, amountBought);
     }
@@ -79,13 +113,31 @@ contract PaymentProcessor is Ownable {
         uint256 amountBought = 0;
         if (intermediaryToken != address(0)) {
             if (intermediaryToken != address(inputToken)) {
-                inputToken.approve(address(tokenExchange), amount);
-                amountBought = tokenExchange.tokenToTokenSwapInput(
-                    amount /* (input) tokens_sold */,
-                    1 /* (output) min_tokens_bought */,
-                    1 /*  min_eth_bought */,
-                    UINT256_MAX /* deadline */,
-                    intermediaryToken /* (input) token_addr */);
+
+                if (isIntermediaryRToken) {
+                    IRToken rToken = IRToken(intermediaryToken);
+                    IERC20 underlying = IERC20(rToken.token());
+                    require (address(underlying) != address(0), "No underlying token for rToken");
+                    if (underlying != inputToken) {
+                        inputToken.approve(address(tokenExchange), amount);
+                        amountBought = tokenExchange.tokenToTokenSwapInput(amount, 1, 1, UINT256_MAX, address(underlying));
+                        underlying.approve(address(rToken), amountBought);
+                        rToken.mint(amountBought);
+
+                    } else {
+                        inputToken.approve(address(rToken), amount);
+                        rToken.mint(amount);
+                        amountBought = amount;
+                    }
+                } else {
+                    inputToken.approve(address(tokenExchange), amount);
+                    amountBought = tokenExchange.tokenToTokenSwapInput(
+                        amount /* (input) tokens_sold */,
+                        1 /* (output) min_tokens_bought */,
+                        1 /*  min_eth_bought */,
+                        UINT256_MAX /* deadline */,
+                        intermediaryToken /* (input) token_addr */);
+                }
             } else {
                 // same token
                 amountBought = amount;
@@ -110,7 +162,13 @@ contract PaymentProcessor is Ownable {
     function withdrawToken(IERC20 token, uint256 amount, address to)
         onlyFundManager
         external {
-        require(token.transfer(to, amount), "Withdraw token failed");
+        if (isIntermediaryRToken) {
+            IRToken rToken = IRToken(intermediaryToken);
+            require(token == rToken.token(), "Supplied token is not underlying token");
+            require(rToken.redeemAndTransfer(to, amount), "Redeeming rTokens failed");
+        } else {
+            require(token.transfer(to, amount), "Withdraw token failed");
+        }
         emit TokenDepositWithdrawn(address(token), to, amount);
     }
 
@@ -140,3 +198,9 @@ contract PaymentProcessor is Ownable {
 
 // for testing
 import { ERC20Mintable } from "openzeppelin-solidity/contracts/token/ERC20/ERC20Mintable.sol";
+import { ComptrollerMock } from "@rtoken/contracts/contracts/test/ComptrollerMock.sol";
+import { InterestRateModelMock } from "@rtoken/contracts/contracts/test/InterestRateModelMock.sol";
+import { CErc20 } from "@rtoken/contracts/compound/contracts/CErc20.sol";
+import { CompoundAllocationStrategy } from "@rtoken/contracts/contracts/CompoundAllocationStrategy.sol";
+import { RToken } from "@rtoken/contracts/contracts/RToken.sol";
+import { Proxy } from "@rtoken/contracts/contracts/Proxy.sol";

--- a/contracts/test/TestBundle.sol
+++ b/contracts/test/TestBundle.sol
@@ -1,0 +1,9 @@
+pragma solidity ^0.5.0;
+
+import { ERC20Mintable } from "@openzeppelin/contracts/token/ERC20/ERC20Mintable.sol";
+import { ComptrollerMock } from "@rtoken/contracts/contracts/test/ComptrollerMock.sol";
+import { InterestRateModelMock } from "@rtoken/contracts/contracts/test/InterestRateModelMock.sol";
+import { CErc20 } from "@rtoken/contracts/compound/contracts/CErc20.sol";
+import { CompoundAllocationStrategy } from "@rtoken/contracts/contracts/CompoundAllocationStrategy.sol";
+import { RToken } from "@rtoken/contracts/contracts/RToken.sol";
+import { Proxy } from "@rtoken/contracts/contracts/Proxy.sol";

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,11 @@
 				}
 			}
 		},
+		"@openzeppelin/contracts": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-2.4.0.tgz",
+			"integrity": "sha512-xeKP59REgow5TPBJh3S9BRIm7DDG+Rz3Nt4ANWGUkjk4305DHpyUD5CyMJ6nd2JMmZuFyx4mjvvlCtSJLRnN6w=="
+		},
 		"@resolver-engine/core": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/@resolver-engine/core/-/core-0.2.1.tgz",
@@ -122,6 +127,14 @@
 				}
 			}
 		},
+		"@rtoken/contracts": {
+			"version": "1.0.1-rc5",
+			"resolved": "https://registry.npmjs.org/@rtoken/contracts/-/contracts-1.0.1-rc5.tgz",
+			"integrity": "sha512-4VB2VJyM/c5lY1vDLf8X6ativYueVg81D0PYZbcUYKz/sCnw+QWY4hTxul+a7X+ylLxPr9PyxyY8lKbc/goHSw==",
+			"requires": {
+				"@openzeppelin/contracts": "2.4.0"
+			}
+		},
 		"@sindresorhus/is": {
 			"version": "0.14.0",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -141,16 +154,17 @@
 			"integrity": "sha512-9MyQ/20M96clhIcC7fVFIckGSB8qMsmcdU6iYt98HXJ9GOLNKsCaJFz1OVsJncVreYwTUhoEXTrVBc8zrmPDJQ=="
 		},
 		"@truffle/contract": {
-			"version": "4.0.37",
-			"resolved": "https://registry.npmjs.org/@truffle/contract/-/contract-4.0.37.tgz",
-			"integrity": "sha512-zCTaTWVDXOJNsBhd2wnIxvb6/610I083ZHKLZ/r/PqY2K8CvhcUsxoAggJowu9O8SN3Ll3gTJGugmx+ip6rbSw==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@truffle/contract/-/contract-4.1.9.tgz",
+			"integrity": "sha512-jZEt/7v0KORibr/V3iUy2R8g2hY2mUSzQ5QoGlG9o1Kdz3dxFPEj3F1xcVGb0IMAYwlFrqtyHr9RuVnN2Agpkw==",
 			"dev": true,
 			"requires": {
-				"@truffle/blockchain-utils": "^0.0.13",
-				"@truffle/contract-schema": "^3.0.16",
-				"@truffle/error": "^0.0.7",
-				"@truffle/interface-adapter": "^0.3.0",
+				"@truffle/blockchain-utils": "^0.0.17",
+				"@truffle/contract-schema": "^3.0.23",
+				"@truffle/error": "^0.0.8",
+				"@truffle/interface-adapter": "^0.4.5",
 				"bignumber.js": "^7.2.1",
+				"ethereum-ens": "^0.8.0",
 				"ethers": "^4.0.0-beta.1",
 				"web3": "1.2.1",
 				"web3-core-promievent": "1.2.1",
@@ -159,15 +173,26 @@
 			},
 			"dependencies": {
 				"@truffle/blockchain-utils": {
-					"version": "0.0.13",
-					"resolved": "https://registry.npmjs.org/@truffle/blockchain-utils/-/blockchain-utils-0.0.13.tgz",
-					"integrity": "sha512-58PNluLrJ967BjoBymWmfa+j9tfDa2GpAjEOiKkQav94aVbrBecDwmd3jOTl3gAhJA21AB3UZxri50mKVHopKw==",
+					"version": "0.0.17",
+					"resolved": "https://registry.npmjs.org/@truffle/blockchain-utils/-/blockchain-utils-0.0.17.tgz",
+					"integrity": "sha512-SqvkHCn65QbRFlNpA3M91tqcV8dVMSEfOu3lfXrPozKJyTTtFg/A8WMvMMs79/Q8SJlUuJARjsXwQmo5V3V78A==",
 					"dev": true
 				},
+				"@truffle/contract-schema": {
+					"version": "3.0.23",
+					"resolved": "https://registry.npmjs.org/@truffle/contract-schema/-/contract-schema-3.0.23.tgz",
+					"integrity": "sha512-N4CaTMcZhOC44Vl6k2r/eua+ojUswl6mNlkVTVYMvWjfKa8GHKKClsZfkGO72aBrBzoTFsM6D75LvQIIRBy3fg==",
+					"dev": true,
+					"requires": {
+						"ajv": "^6.10.0",
+						"crypto-js": "^3.1.9-1",
+						"debug": "^4.1.0"
+					}
+				},
 				"@truffle/error": {
-					"version": "0.0.7",
-					"resolved": "https://registry.npmjs.org/@truffle/error/-/error-0.0.7.tgz",
-					"integrity": "sha512-UIfVKsXSXocKnn5+RNklUXNoGd/JVj7V8KmC48TQzmjU33HQI86PX0JDS7SpHMHasI3w9X//1q7Lu7nZtj3Zzg==",
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/@truffle/error/-/error-0.0.8.tgz",
+					"integrity": "sha512-x55rtRuNfRO1azmZ30iR0pf0OJ6flQqbax1hJz+Avk1K5fdmOv5cr22s9qFnwTWnS6Bw0jvJEoR0ITsM7cPKtQ==",
 					"dev": true
 				}
 			}
@@ -188,9 +213,9 @@
 			"integrity": "sha512-QUM9ZWiwlXGixFGpV18g5I6vua6/r+ZV9W/5DQA5go9A3eZUNPHPaTKMIQPJLYn6+ZV5jg5H28zCHq56LHF3yA=="
 		},
 		"@truffle/interface-adapter": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@truffle/interface-adapter/-/interface-adapter-0.3.0.tgz",
-			"integrity": "sha512-peay1/ivdgYC656exZRlZcvYlbZKBM0BAMuUENAH7Z12RpbY50GXGsVbxWk+neLp9dA/tDIMOE04/iyn0GAnbQ==",
+			"version": "0.4.5",
+			"resolved": "https://registry.npmjs.org/@truffle/interface-adapter/-/interface-adapter-0.4.5.tgz",
+			"integrity": "sha512-NGR2UsUXaG6LVezDKqtyqbi7o2UIZJzPmXDybfu0bZ1B1FbdJWXdtLgiPZSlC8IK5Js1V3ruqougX3b4YV5Dfw==",
 			"dev": true,
 			"requires": {
 				"bn.js": "^4.11.8",
@@ -258,8 +283,7 @@
 		"app-module-path": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
-			"integrity": "sha1-ZBqlXft9am8KgUHEucCqULbCTdU=",
-			"dev": true
+			"integrity": "sha1-ZBqlXft9am8KgUHEucCqULbCTdU="
 		},
 		"argparse": {
 			"version": "1.0.10",
@@ -327,8 +351,7 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"base64-js": {
 			"version": "1.3.1",
@@ -426,7 +449,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -440,8 +462,7 @@
 		"browser-stdout": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-			"dev": true
+			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
 		},
 		"browserify-aes": {
 			"version": "1.2.0",
@@ -740,8 +761,7 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"content-disposition": {
 			"version": "0.5.3",
@@ -1023,8 +1043,7 @@
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-			"dev": true
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
 		},
 		"diffie-hellman": {
 			"version": "5.0.3",
@@ -1172,8 +1191,7 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"esprima": {
 			"version": "4.0.1",
@@ -1227,6 +1245,28 @@
 				"ethereumjs-util": "^5.1.1",
 				"tweetnacl": "^1.0.0",
 				"tweetnacl-util": "^0.15.0"
+			}
+		},
+		"ethereum-ens": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/ethereum-ens/-/ethereum-ens-0.8.0.tgz",
+			"integrity": "sha512-a8cBTF4AWw1Q1Y37V1LSCS9pRY4Mh3f8vCg5cbXCCEJ3eno1hbI/+Ccv9SZLISYpqQhaglP3Bxb/34lS4Qf7Bg==",
+			"dev": true,
+			"requires": {
+				"bluebird": "^3.4.7",
+				"eth-ens-namehash": "^2.0.0",
+				"js-sha3": "^0.5.7",
+				"pako": "^1.0.4",
+				"underscore": "^1.8.3",
+				"web3": "^1.0.0-beta.34"
+			},
+			"dependencies": {
+				"js-sha3": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+					"integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
+					"dev": true
+				}
 			}
 		},
 		"ethereumjs-abi": {
@@ -1575,8 +1615,7 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"function-bind": {
 			"version": "1.1.1",
@@ -1665,8 +1704,7 @@
 		"growl": {
 			"version": "1.10.5",
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-			"dev": true
+			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
 		},
 		"har-schema": {
 			"version": "2.0.0",
@@ -1693,8 +1731,7 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
 		"has-symbol-support-x": {
 			"version": "1.4.2",
@@ -1825,7 +1862,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -2160,7 +2196,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -2430,8 +2465,7 @@
 		"original-require": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/original-require/-/original-require-1.0.1.tgz",
-			"integrity": "sha1-DxMEcVhM0zURxew4yNWSE/msXiA=",
-			"dev": true
+			"integrity": "sha1-DxMEcVhM0zURxew4yNWSE/msXiA="
 		},
 		"p-cancelable": {
 			"version": "1.1.0",
@@ -2475,6 +2509,12 @@
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 			"dev": true
 		},
+		"pako": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+			"dev": true
+		},
 		"parse-asn1": {
 			"version": "5.1.5",
 			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
@@ -2511,8 +2551,7 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-to-regexp": {
 			"version": "0.1.7",
@@ -3221,7 +3260,6 @@
 			"version": "5.0.42",
 			"resolved": "https://registry.npmjs.org/truffle/-/truffle-5.0.42.tgz",
 			"integrity": "sha512-WbXGdHElluVbQP9FQljpvBLWjSEiKHaUx27TZ+RK7yEyrYDb8ATjpX0Owkc72bIy3AjKcbrlrptnqYswY1mtsg==",
-			"dev": true,
 			"requires": {
 				"app-module-path": "^2.2.0",
 				"mocha": "5.2.0",
@@ -3231,14 +3269,12 @@
 				"commander": {
 					"version": "2.15.1",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-					"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-					"dev": true
+					"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
 				},
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -3247,7 +3283,6 @@
 					"version": "7.1.2",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"dev": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
 						"inflight": "^1.0.4",
@@ -3260,14 +3295,12 @@
 				"he": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-					"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-					"dev": true
+					"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
 				},
 				"mocha": {
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
 					"integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
-					"dev": true,
 					"requires": {
 						"browser-stdout": "1.3.1",
 						"commander": "2.15.1",
@@ -3285,14 +3318,12 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				},
 				"supports-color": {
 					"version": "5.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -3816,7 +3847,7 @@
 			"requires": {
 				"underscore": "1.9.1",
 				"web3-core-helpers": "1.2.1",
-				"websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
+				"websocket": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e"
 			}
 		},
 		"web3-shh": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,29 +5,58 @@
 	"requires": true,
 	"dependencies": {
 		"@decentral.ee/web3-test-helpers": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/@decentral.ee/web3-test-helpers/-/web3-test-helpers-0.2.1.tgz",
-			"integrity": "sha512-ysi/n4rtOao0pG7aymofQiFlU+vZBLwB/8YvrexaextUJ7Lo1JOs446jCrUcEkQWeYZCKhOxlS2dQh3sR/w3Cw==",
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/@decentral.ee/web3-test-helpers/-/web3-test-helpers-0.2.4.tgz",
+			"integrity": "sha512-9PLTxqYbqbcK1UNFRdEjikLN7GospSkVp7Om0ZobDs857uhtTLfcNI1ezyr925r38UrPEqy6sVpxUCYzYWIWPA==",
+			"dev": true
+		},
+		"@openzeppelin/contract-loader": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@openzeppelin/contract-loader/-/contract-loader-0.4.0.tgz",
+			"integrity": "sha512-K+Pl4tn0FbxMSP0H9sgi61ayCbecpqhQmuBshelC7A3q2MlpcqWRJan0xijpwdtv6TORNd5oZNe/+f3l+GD6tw==",
 			"dev": true,
 			"requires": {
-				"chai": "^4.2.0",
-				"openzeppelin-test-helpers": "^0.4.0"
+				"find-up": "^4.1.0",
+				"fs-extra": "^8.1.0",
+				"try-require": "^1.2.1"
 			},
 			"dependencies": {
-				"openzeppelin-test-helpers": {
-					"version": "0.4.3",
-					"resolved": "https://registry.npmjs.org/openzeppelin-test-helpers/-/openzeppelin-test-helpers-0.4.3.tgz",
-					"integrity": "sha512-ln5Exl5fciLIKIUZ6yX6Q2kO/XMQLhNh8G/uEcVfIPZCl/Q0z64ayqZZmsQLGJx1HpSZS27XjC5d48PjX72eEw==",
+				"fs-extra": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
 					"dev": true,
 					"requires": {
-						"ansi-colors": "^3.2.3",
-						"chai-bn": "^0.1.1",
-						"ethjs-abi": "^0.2.1",
-						"semver": "^5.6.0",
-						"truffle-contract": "^4.0.26",
-						"web3-utils": "^1.2.0"
+						"graceful-fs": "^4.2.0",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
 					}
-				},
+				}
+			}
+		},
+		"@openzeppelin/contracts": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-2.5.0.tgz",
+			"integrity": "sha512-t3jm8FrhL9tkkJTofkznTqo/XXdHi21w5yXwalEnaMOp22ZwZ0f/mmKdlgMMLPFa6bSVHbY88mKESwJT/7m5Lg=="
+		},
+		"@openzeppelin/test-helpers": {
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/@openzeppelin/test-helpers/-/test-helpers-0.5.4.tgz",
+			"integrity": "sha512-sSjft0CcmC6Pwsd/j1uakk2MLamEH4mmphVlF5hzUUVyoxL0KGCbxQgBoLoEpUbw2M9HtFAEMJJPGccEcb9Cog==",
+			"dev": true,
+			"requires": {
+				"@openzeppelin/contract-loader": "^0.4.0",
+				"@truffle/contract": "^4.0.35",
+				"ansi-colors": "^3.2.3",
+				"chai": "^4.2.0",
+				"chai-bn": "^0.2.0",
+				"ethjs-abi": "^0.2.1",
+				"lodash.flatten": "^4.4.0",
+				"semver": "^5.6.0",
+				"web3": "^1.2.1",
+				"web3-utils": "^1.2.1"
+			},
+			"dependencies": {
 				"semver": {
 					"version": "5.7.1",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -35,11 +64,6 @@
 					"dev": true
 				}
 			}
-		},
-		"@openzeppelin/contracts": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-2.4.0.tgz",
-			"integrity": "sha512-xeKP59REgow5TPBJh3S9BRIm7DDG+Rz3Nt4ANWGUkjk4305DHpyUD5CyMJ6nd2JMmZuFyx4mjvvlCtSJLRnN6w=="
 		},
 		"@resolver-engine/core": {
 			"version": "0.2.1",
@@ -133,6 +157,13 @@
 			"integrity": "sha512-4VB2VJyM/c5lY1vDLf8X6ativYueVg81D0PYZbcUYKz/sCnw+QWY4hTxul+a7X+ylLxPr9PyxyY8lKbc/goHSw==",
 			"requires": {
 				"@openzeppelin/contracts": "2.4.0"
+			},
+			"dependencies": {
+				"@openzeppelin/contracts": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-2.4.0.tgz",
+					"integrity": "sha512-xeKP59REgow5TPBJh3S9BRIm7DDG+Rz3Nt4ANWGUkjk4305DHpyUD5CyMJ6nd2JMmZuFyx4mjvvlCtSJLRnN6w=="
+				}
 			}
 		},
 		"@sindresorhus/is": {
@@ -280,10 +311,21 @@
 			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
 			"integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
 		},
+		"anymatch": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+			"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+			"dev": true,
+			"requires": {
+				"normalize-path": "^3.0.0",
+				"picomatch": "^2.0.4"
+			}
+		},
 		"app-module-path": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
-			"integrity": "sha1-ZBqlXft9am8KgUHEucCqULbCTdU="
+			"integrity": "sha1-ZBqlXft9am8KgUHEucCqULbCTdU=",
+			"dev": true
 		},
 		"argparse": {
 			"version": "1.0.10",
@@ -351,7 +393,8 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
 		},
 		"base64-js": {
 			"version": "1.3.1",
@@ -377,6 +420,12 @@
 			"version": "7.2.1",
 			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
 			"integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+		},
+		"binary-extensions": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+			"integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+			"dev": true
 		},
 		"bindings": {
 			"version": "1.5.0",
@@ -449,9 +498,19 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
+			}
+		},
+		"braces": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"dev": true,
+			"requires": {
+				"fill-range": "^7.0.1"
 			}
 		},
 		"brorand": {
@@ -462,7 +521,8 @@
 		"browser-stdout": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+			"dev": true
 		},
 		"browserify-aes": {
 			"version": "1.2.0",
@@ -633,9 +693,9 @@
 			}
 		},
 		"chai-bn": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/chai-bn/-/chai-bn-0.1.1.tgz",
-			"integrity": "sha512-e1npVXt3cQfZ6oQET9oP38vNj/4HeJ4ojeUpuC8YzhVbTJpIDqANVt7TKi7Dq9yKlHySk2FqbmiMih35iT4DYg==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/chai-bn/-/chai-bn-0.2.0.tgz",
+			"integrity": "sha512-h+XqIFikre13N3uiZSc50PZ0VztVjuD/Gytle07EUFkbd8z31tWp37DLAsR1dPozmOLA3yu4hi3IFjJDQ5CKBg==",
 			"dev": true
 		},
 		"chalk": {
@@ -665,6 +725,22 @@
 			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
 			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
 			"dev": true
+		},
+		"chokidar": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
+			"integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+			"dev": true,
+			"requires": {
+				"anymatch": "~3.1.1",
+				"braces": "~3.0.2",
+				"fsevents": "~2.1.1",
+				"glob-parent": "~5.1.0",
+				"is-binary-path": "~2.1.0",
+				"is-glob": "~4.0.1",
+				"normalize-path": "~3.0.0",
+				"readdirp": "~3.2.0"
+			}
 		},
 		"chownr": {
 			"version": "1.1.3",
@@ -761,7 +837,8 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"content-disposition": {
 			"version": "0.5.3",
@@ -868,15 +945,6 @@
 			"version": "3.1.9-1",
 			"resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
 			"integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
-		},
-		"d": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-			"integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-			"requires": {
-				"es5-ext": "^0.10.50",
-				"type": "^1.0.1"
-			}
 		},
 		"dashdash": {
 			"version": "1.14.1",
@@ -1043,7 +1111,8 @@
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+			"dev": true
 		},
 		"diffie-hellman": {
 			"version": "5.0.3",
@@ -1154,35 +1223,6 @@
 				"is-symbol": "^1.0.2"
 			}
 		},
-		"es5-ext": {
-			"version": "0.10.51",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.51.tgz",
-			"integrity": "sha512-oRpWzM2WcLHVKpnrcyB7OW8j/s67Ba04JCm0WnNv3RiABSvs7mrQlutB8DBv793gKcp0XENR8Il8WxGTlZ73gQ==",
-			"requires": {
-				"es6-iterator": "~2.0.3",
-				"es6-symbol": "~3.1.1",
-				"next-tick": "^1.0.0"
-			}
-		},
-		"es6-iterator": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-			"requires": {
-				"d": "1",
-				"es5-ext": "^0.10.35",
-				"es6-symbol": "^3.1.1"
-			}
-		},
-		"es6-symbol": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.2.tgz",
-			"integrity": "sha512-/ZypxQsArlv+KHpGvng52/Iz8by3EQPxhmbuz8yFG89N/caTFBSbcXONDw0aMjy827gQg26XAjP4uXFvnfINmQ==",
-			"requires": {
-				"d": "^1.0.1",
-				"es5-ext": "^0.10.51"
-			}
-		},
 		"escape-html": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -1191,7 +1231,8 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
 		},
 		"esprima": {
 			"version": "4.0.1",
@@ -1235,9 +1276,9 @@
 			}
 		},
 		"eth-sig-util": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.5.0.tgz",
-			"integrity": "sha512-ahApxr+e1cls/GwcFSGsgRLrMqG6D6cBnK9CRHhx97O/s9ow+URIxbPvov8jfE70ZnNBdHMircoSCpi1b4QHjA==",
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.5.2.tgz",
+			"integrity": "sha512-xvDojS/4reXsw8Pz/+p/qcM5rVB61FOdPbEtMZ8FQ0YHnPEzPy5F8zAAaZ+zj5ud0SwRLWPfor2Cacjm7EzMIw==",
 			"requires": {
 				"buffer": "^5.2.1",
 				"elliptic": "^6.4.0",
@@ -1509,6 +1550,15 @@
 			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
 			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
 		},
+		"fill-range": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"dev": true,
+			"requires": {
+				"to-regex-range": "^5.0.1"
+			}
+		},
 		"finalhandler": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
@@ -1539,12 +1589,21 @@
 			}
 		},
 		"find-up": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
 			"dev": true,
 			"requires": {
-				"locate-path": "^3.0.0"
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"dependencies": {
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				}
 			}
 		},
 		"flat": {
@@ -1615,7 +1674,15 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"fsevents": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+			"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+			"dev": true,
+			"optional": true
 		},
 		"function-bind": {
 			"version": "1.1.1",
@@ -1664,6 +1731,15 @@
 				"path-is-absolute": "^1.0.0"
 			}
 		},
+		"glob-parent": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+			"integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+			"dev": true,
+			"requires": {
+				"is-glob": "^4.0.1"
+			}
+		},
 		"global": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
@@ -1704,7 +1780,8 @@
 		"growl": {
 			"version": "1.10.5",
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
+			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+			"dev": true
 		},
 		"har-schema": {
 			"version": "2.0.0",
@@ -1731,7 +1808,8 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
 		},
 		"has-symbol-support-x": {
 			"version": "1.4.2",
@@ -1862,6 +1940,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -1876,6 +1955,15 @@
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
 			"integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
+		},
+		"is-binary-path": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+			"dev": true,
+			"requires": {
+				"binary-extensions": "^2.0.0"
+			}
 		},
 		"is-buffer": {
 			"version": "2.0.4",
@@ -1893,6 +1981,12 @@
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
 			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
 		},
+		"is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+			"dev": true
+		},
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -1904,6 +1998,15 @@
 			"resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
 			"integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
 		},
+		"is-glob": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+			"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+			"dev": true,
+			"requires": {
+				"is-extglob": "^2.1.1"
+			}
+		},
 		"is-hex-prefixed": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
@@ -1913,6 +2016,12 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
 			"integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
+		},
+		"is-number": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"dev": true
 		},
 		"is-object": {
 			"version": "1.0.1",
@@ -2068,13 +2177,12 @@
 			}
 		},
 		"locate-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
 			"dev": true,
 			"requires": {
-				"p-locate": "^3.0.0",
-				"path-exists": "^3.0.0"
+				"p-locate": "^4.1.0"
 			}
 		},
 		"lodash": {
@@ -2196,6 +2304,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -2239,13 +2348,14 @@
 			}
 		},
 		"mocha": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.2.tgz",
-			"integrity": "sha512-FgDS9Re79yU1xz5d+C4rv1G7QagNGHZ+iXF81hO8zY35YZZcLEsJVfFolfsqKFWunATEvNzMK0r/CwWd/szO9A==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-7.0.1.tgz",
+			"integrity": "sha512-9eWmWTdHLXh72rGrdZjNbG3aa1/3NRPpul1z0D979QpEnFdCG0Q5tv834N+94QEN2cysfV72YocQ3fn87s70fg==",
 			"dev": true,
 			"requires": {
 				"ansi-colors": "3.2.3",
 				"browser-stdout": "1.3.1",
+				"chokidar": "3.3.0",
 				"debug": "3.2.6",
 				"diff": "3.5.0",
 				"escape-string-regexp": "1.0.5",
@@ -2258,7 +2368,7 @@
 				"minimatch": "3.0.4",
 				"mkdirp": "0.5.1",
 				"ms": "2.1.1",
-				"node-environment-flags": "1.0.5",
+				"node-environment-flags": "1.0.6",
 				"object.assign": "4.1.0",
 				"strip-json-comments": "2.0.1",
 				"supports-color": "6.0.0",
@@ -2284,11 +2394,39 @@
 						"ms": "^2.1.1"
 					}
 				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
 				"ms": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
 					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
 					"dev": true
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
 				}
 			}
 		},
@@ -2317,15 +2455,10 @@
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
 			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
 		},
-		"next-tick": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
-		},
 		"node-environment-flags": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
-			"integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
+			"integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
 			"dev": true,
 			"requires": {
 				"object.getownpropertydescriptors": "^2.0.3",
@@ -2339,6 +2472,12 @@
 					"dev": true
 				}
 			}
+		},
+		"normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"dev": true
 		},
 		"normalize-url": {
 			"version": "4.5.0",
@@ -2394,13 +2533,92 @@
 			}
 		},
 		"object.getownpropertydescriptors": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+			"integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.5.1"
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0-next.1"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.17.4",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
+					"integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+					"dev": true,
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.1.5",
+						"is-regex": "^1.0.5",
+						"object-inspect": "^1.7.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.0",
+						"string.prototype.trimleft": "^2.1.1",
+						"string.prototype.trimright": "^2.1.1"
+					}
+				},
+				"es-to-primitive": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+					"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+					"dev": true,
+					"requires": {
+						"is-callable": "^1.1.4",
+						"is-date-object": "^1.0.1",
+						"is-symbol": "^1.0.2"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+					"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+					"dev": true
+				},
+				"is-callable": {
+					"version": "1.1.5",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+					"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+					"dev": true
+				},
+				"is-regex": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+					"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+					"dev": true,
+					"requires": {
+						"has": "^1.0.3"
+					}
+				},
+				"object-inspect": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+					"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+					"dev": true
+				},
+				"string.prototype.trimleft": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+					"integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+					"dev": true,
+					"requires": {
+						"define-properties": "^1.1.3",
+						"function-bind": "^1.1.1"
+					}
+				},
+				"string.prototype.trimright": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+					"integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+					"dev": true,
+					"requires": {
+						"define-properties": "^1.1.3",
+						"function-bind": "^1.1.1"
+					}
+				}
 			}
 		},
 		"oboe": {
@@ -2427,45 +2645,11 @@
 				"wrappy": "1"
 			}
 		},
-		"openzeppelin-solidity": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.3.0.tgz",
-			"integrity": "sha512-QYeiPLvB1oSbDt6lDQvvpx7k8ODczvE474hb2kLXZBPKMsxKT1WxTCHBYrCU7kS7hfAku4DcJ0jqOyL+jvjwQw=="
-		},
-		"openzeppelin-test-helpers": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/openzeppelin-test-helpers/-/openzeppelin-test-helpers-0.5.1.tgz",
-			"integrity": "sha512-xIMusuVCKXfR+qwbyiXpV7UaqaW3H/Q3axQ2nSce8o3R9TQoxrZdbKvMZdJdg6Ro4cpRDQ3yZtniz4vSIbSZHg==",
-			"dev": true,
-			"requires": {
-				"@truffle/contract": "^4.0.35",
-				"ansi-colors": "^3.2.3",
-				"chai-bn": "^0.2.0",
-				"ethjs-abi": "^0.2.1",
-				"lodash.flatten": "^4.4.0",
-				"semver": "^5.6.0",
-				"web3": "^1.2.1",
-				"web3-utils": "^1.2.1"
-			},
-			"dependencies": {
-				"chai-bn": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/chai-bn/-/chai-bn-0.2.0.tgz",
-					"integrity": "sha512-h+XqIFikre13N3uiZSc50PZ0VztVjuD/Gytle07EUFkbd8z31tWp37DLAsR1dPozmOLA3yu4hi3IFjJDQ5CKBg==",
-					"dev": true
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
-			}
-		},
 		"original-require": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/original-require/-/original-require-1.0.1.tgz",
-			"integrity": "sha1-DxMEcVhM0zURxew4yNWSE/msXiA="
+			"integrity": "sha1-DxMEcVhM0zURxew4yNWSE/msXiA=",
+			"dev": true
 		},
 		"p-cancelable": {
 			"version": "1.1.0",
@@ -2478,21 +2662,21 @@
 			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
 		},
 		"p-limit": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-			"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+			"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
 			"dev": true,
 			"requires": {
 				"p-try": "^2.0.0"
 			}
 		},
 		"p-locate": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
 			"dev": true,
 			"requires": {
-				"p-limit": "^2.0.0"
+				"p-limit": "^2.2.0"
 			}
 		},
 		"p-timeout": {
@@ -2551,7 +2735,8 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
 		},
 		"path-to-regexp": {
 			"version": "0.1.7",
@@ -2585,6 +2770,12 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+		},
+		"picomatch": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
+			"integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
+			"dev": true
 		},
 		"pify": {
 			"version": "2.3.0",
@@ -2734,6 +2925,15 @@
 				}
 			}
 		},
+		"readdirp": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
+			"integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+			"dev": true,
+			"requires": {
+				"picomatch": "^2.0.4"
+			}
+		},
 		"request": {
 			"version": "2.88.0",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
@@ -2803,12 +3003,11 @@
 			}
 		},
 		"rlp": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.3.tgz",
-			"integrity": "sha512-l6YVrI7+d2vpW6D6rS05x2Xrmq8oW7v3pieZOJKBEdjuTF4Kz/iwk55Zyh1Zaz+KOB2kC8+2jZlp2u9L4tTzCQ==",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.4.tgz",
+			"integrity": "sha512-fdq2yYCWpAQBhwkZv+Z8o/Z4sPmYm1CUq6P7n6lVTOdb949CnqA0sndXal5C1NleSVSZm6q5F3iEbauyVln/iw==",
 			"requires": {
-				"bn.js": "^4.11.1",
-				"safe-buffer": "^5.1.1"
+				"bn.js": "^4.11.1"
 			}
 		},
 		"safe-buffer": {
@@ -2832,20 +3031,34 @@
 			"integrity": "sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w=="
 		},
 		"secp256k1": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
-			"integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
+			"integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
 			"requires": {
 				"bindings": "^1.5.0",
 				"bip66": "^1.1.5",
 				"bn.js": "^4.11.8",
 				"create-hash": "^1.2.0",
 				"drbg.js": "^1.0.1",
-				"elliptic": "^6.4.1",
+				"elliptic": "^6.5.2",
 				"nan": "^2.14.0",
 				"safe-buffer": "^5.1.2"
 			},
 			"dependencies": {
+				"elliptic": {
+					"version": "6.5.2",
+					"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
+					"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+					"requires": {
+						"bn.js": "^4.4.0",
+						"brorand": "^1.0.1",
+						"hash.js": "^1.0.0",
+						"hmac-drbg": "^1.0.0",
+						"inherits": "^2.0.1",
+						"minimalistic-assert": "^1.0.0",
+						"minimalistic-crypto-utils": "^1.0.0"
+					}
+				},
 				"nan": {
 					"version": "2.14.0",
 					"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
@@ -3235,6 +3448,15 @@
 			"resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
 			"integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q=="
 		},
+		"to-regex-range": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"dev": true,
+			"requires": {
+				"is-number": "^7.0.0"
+			}
+		},
 		"toidentifier": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
@@ -3257,9 +3479,10 @@
 			}
 		},
 		"truffle": {
-			"version": "5.0.42",
-			"resolved": "https://registry.npmjs.org/truffle/-/truffle-5.0.42.tgz",
-			"integrity": "sha512-WbXGdHElluVbQP9FQljpvBLWjSEiKHaUx27TZ+RK7yEyrYDb8ATjpX0Owkc72bIy3AjKcbrlrptnqYswY1mtsg==",
+			"version": "5.1.13",
+			"resolved": "https://registry.npmjs.org/truffle/-/truffle-5.1.13.tgz",
+			"integrity": "sha512-d+DKgNE389/WmSb68sDu/DnMpex18bx7edw4waSEESdynwTgocsPFumgWqzmmUTxjnaRAScPC7oA5X6ZVSKwLQ==",
+			"dev": true,
 			"requires": {
 				"app-module-path": "^2.2.0",
 				"mocha": "5.2.0",
@@ -3269,12 +3492,14 @@
 				"commander": {
 					"version": "2.15.1",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-					"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+					"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+					"dev": true
 				},
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -3283,6 +3508,7 @@
 					"version": "7.1.2",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"dev": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
 						"inflight": "^1.0.4",
@@ -3295,12 +3521,14 @@
 				"he": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-					"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+					"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+					"dev": true
 				},
 				"mocha": {
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
 					"integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+					"dev": true,
 					"requires": {
 						"browser-stdout": "1.3.1",
 						"commander": "2.15.1",
@@ -3318,12 +3546,14 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "5.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -3416,6 +3646,12 @@
 				"web3": "1.2.1"
 			}
 		},
+		"try-require": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/try-require/-/try-require-1.2.1.tgz",
+			"integrity": "sha1-NEiaLKwMCcHMEO2RugEVlNQzO+I=",
+			"dev": true
+		},
 		"tsort": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/tsort/-/tsort-0.0.1.tgz",
@@ -3431,19 +3667,14 @@
 			}
 		},
 		"tweetnacl": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
-			"integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+			"integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
 		},
 		"tweetnacl-util": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.0.tgz",
-			"integrity": "sha1-RXbBzuXi1j0gf+5S8boCgZSAvHU="
-		},
-		"type": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-			"integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
+			"integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw=="
 		},
 		"type-detect": {
 			"version": "4.0.8",
@@ -3458,14 +3689,6 @@
 			"requires": {
 				"media-typer": "0.3.0",
 				"mime-types": "~2.1.24"
-			}
-		},
-		"typedarray-to-buffer": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-			"requires": {
-				"is-typedarray": "^1.0.0"
 			}
 		},
 		"ultron": {
@@ -3846,8 +4069,38 @@
 			"integrity": "sha512-oqsQXzu+ejJACVHy864WwIyw+oB21nw/pI65/sD95Zi98+/HQzFfNcIFneF1NC4bVF3VNX4YHTNq2I2o97LAiA==",
 			"requires": {
 				"underscore": "1.9.1",
-				"web3-core-helpers": "1.2.1",
-				"websocket": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e"
+				"web3-core-helpers": "1.2.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"nan": {
+					"version": "2.14.0",
+					"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+					"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+				},
+				"websocket": {
+					"version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
+					"from": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
+					"requires": {
+						"debug": "^2.2.0",
+						"es5-ext": "^0.10.50",
+						"nan": "^2.14.0",
+						"typedarray-to-buffer": "^3.1.5",
+						"yaeti": "^0.0.6"
+					}
+				}
 			}
 		},
 		"web3-shh": {
@@ -3884,37 +4137,6 @@
 						"elliptic": "^6.4.0",
 						"xhr-request-promise": "^0.1.2"
 					}
-				}
-			}
-		},
-		"websocket": {
-			"version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
-			"from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
-			"requires": {
-				"debug": "^2.2.0",
-				"es5-ext": "^0.10.50",
-				"nan": "^2.14.0",
-				"typedarray-to-buffer": "^3.1.5",
-				"yaeti": "^0.0.6"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-				},
-				"nan": {
-					"version": "2.14.0",
-					"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-					"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
 				}
 			}
 		},
@@ -4060,11 +4282,6 @@
 			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
 			"dev": true
 		},
-		"yaeti": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-			"integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
-		},
 		"yallist": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -4093,6 +4310,34 @@
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
 					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
 					"dev": true
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
 				},
 				"string-width": {
 					"version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -4,22 +4,22 @@
     "description": "Ethereum phone booth smart contracts",
     "license": "MIT",
     "dependencies": {
+        "@openzeppelin/contracts": "2.5.0",
         "@rtoken/contracts": "^1.0.1-rc5",
-        "eth-sig-util": "2.5.0",
+        "eth-sig-util": "2.5.2",
         "eip712-helpers": "1.0.2",
-        "openzeppelin-solidity": "2.3.0",
         "truffle-contract": "4.0.31"
     },
     "devDependencies": {
         "chai": "4.2.0",
-        "mocha": "6.2.2",
-        "@decentral.ee/web3-test-helpers": "0.2.1",
-        "openzeppelin-test-helpers": "0.5.1",
-        "truffle": "5.0.42",
+        "mocha": "7.0.1",
+        "@decentral.ee/web3-test-helpers": "0.2.4",
+        "@openzeppelin/test-helpers": "0.5.4",
+        "truffle": "5.1.13",
         "truffle-flattener": "1.4.2"
     },
     "scripts": {
-        "test": "npm run build:truffle:compile && truffle test --network local test/all.js",
+        "test": "npm run build:truffle:compile && truffle test test/all.js",
         "build": "npm run build:truffle:compile",
         "build:truffle:compile": "rm -f build/contracts/*;truffle compile",
         "dev": "nodemon -e sol,js -i build -x 'npm run lint && npm run build && npm run test 2>&1'",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Ethereum phone booth smart contracts",
     "license": "MIT",
     "dependencies": {
-        "@EtherPhoneBooth/config": "0.0.1",
+        "@rtoken/contracts": "^1.0.1-rc5",
         "eth-sig-util": "2.5.0",
         "eip712-helpers": "1.0.2",
         "openzeppelin-solidity": "2.3.0",

--- a/test/PaymentProcessor.test.js
+++ b/test/PaymentProcessor.test.js
@@ -2,7 +2,14 @@ const PaymentProcessor = artifacts.require("PaymentProcessor");
 const ERC20Mintable = artifacts.require("ERC20Mintable");
 const { UniswapFactory, UniswapExchange } = require("../uniswap");
 const { expectRevert } = require("openzeppelin-test-helpers");
-const { web3tx } = require("@decentral.ee/web3-test-helpers");
+const { web3tx, toWad } = require("@decentral.ee/web3-test-helpers");
+
+const ComptrollerMock = artifacts.require("ComptrollerMock");
+const InterestRateModelMock = artifacts.require("InterestRateModelMock");
+const CErc20 = artifacts.require("CErc20");
+const CompoundAllocationStrategy = artifacts.require("CompoundAllocationStrategy");
+const RToken = artifacts.require("RToken");
+const Proxy = artifacts.require("Proxy");
 
 contract("PaymentProcessor", accounts => {
     const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
@@ -16,6 +23,36 @@ contract("PaymentProcessor", accounts => {
     let chainId;
     let uniswapFactory;
     let pp;
+
+    //rToken variables
+    let underlyingToken;
+    let cToken;
+    let compoundAS;
+    let rToken;
+    let rTokenLogic;
+    let SELF_HAT_ID;
+
+    async function createCompoundAllocationStrategy(cTokenExchangeRate) {
+        const comptroller = await web3tx(ComptrollerMock.new, "ComptrollerMock.new")({ from: admin });
+        const interestRateModel = await web3tx(InterestRateModelMock.new, "InterestRateModelMock.new")({ from: admin });
+        const cToken = await web3tx(CErc20.new, "CErc20.new")(
+            underlyingToken.address,
+            comptroller.address,
+            interestRateModel.address,
+            cTokenExchangeRate, // 1 cToken == cTokenExchangeRate * token
+            "Compound token",
+            "cToken",
+            18, {
+                from: admin
+            });
+        const compoundAS = await web3tx(CompoundAllocationStrategy.new, "CompoundAllocationStrategy.new")(
+            cToken.address, {
+                from: admin
+            }
+        );
+        return { cToken, compoundAS };
+    }
+
 
     before(async () => {
         chainId = await web3.eth.net.getId();
@@ -40,6 +77,37 @@ contract("PaymentProcessor", accounts => {
 
         await web3tx(pp.setFundManager, "setFundManager")(fundManager,  { from: admin });
         await web3tx(pp.setDepositAgent, "setDepositAgent")(depositAgent,  { from: admin });
+
+        //setup rToken
+        underlyingToken = await web3tx(ERC20Mintable.new, "ERC20Mintable.new")({ from: admin });
+        await web3tx(underlyingToken.mint, "token.mint 1000 -> customer1")(customer1, toWad(1000), { from: admin });
+
+        const result = await createCompoundAllocationStrategy(toWad(.1));
+        cToken = result.cToken;
+        compoundAS = result.compoundAS;
+
+        // Deploy the rToken logic/library contract
+        rTokenLogic = await web3tx(RToken.new, "RToken.new")(
+            {
+                from: admin
+            });
+        // Get the init code for rToken
+        const rTokenConstructCode = rTokenLogic.contract.methods.initialize(
+            compoundAS.address,
+            "RToken Test",
+            "RTOKEN",
+            18).encodeABI();
+
+        // Deploy the Proxy, using the init code for rToken
+        const proxy = await web3tx(Proxy.new, "Proxy.new")(
+            rTokenConstructCode, rTokenLogic.address, {
+                from: admin
+            });
+        // Create the rToken object using the proxy address
+        rToken = await RToken.at(proxy.address);
+
+        await web3tx(compoundAS.transferOwnership, "compoundAS.transferOwnership")(rToken.address);
+        SELF_HAT_ID = await rToken.SELF_HAT_ID.call();
     });
 
     it("deposit and withdraw ether", async () => {
@@ -206,5 +274,170 @@ contract("PaymentProcessor", accounts => {
             }]
         })(1, customer2, tokenA.address, 10, { from: depositAgent });
         assert.equal((await tokenB.balanceOf.call(pp.address)).toString(), "195");
+    });
+
+    it("deposit Ether and redeem rToken", async () => {
+        //create exchange for the underlying token
+        await web3tx(uniswapFactory.createExchange, "uniswapFactory.createExchange")(underlyingToken.address, { from: admin });
+        const underlyingTokenExchangeAddress = await uniswapFactory.getExchange.call(underlyingToken.address);
+        console.log("exchange for inputToken created at: ", underlyingTokenExchangeAddress);
+        const underlyingTokenExchange = await UniswapExchange.at(underlyingTokenExchangeAddress);
+        await web3tx(underlyingToken.mint, "underlying token mint 1000 tokens")(admin, 1000, { from: admin });
+        await web3tx(underlyingToken.approve, "underlying token approve exchange 1000 tokens")(
+            underlyingTokenExchangeAddress,
+            1000,
+            { from: admin });
+        await web3tx(underlyingTokenExchange.addLiquidity, "underlyingTokenExchange.addLiquidity 0.01 ETH <-> 1000 tokens")(
+            0,
+            1000,
+            MAX_DEADLINE,
+            { from: admin, value: web3.utils.toWei("0.01", "ether") });
+        // 1 x underlying token = 0.01 / 1000 ~= 0.00001 ~= 0.0000099 ETH
+        assert.isTrue(web3.utils.fromWei(await underlyingTokenExchange.getTokenToEthInputPrice.call(1), "ether").startsWith("0.0000099"));
+
+        //set RToken as the intermediary token
+        await web3tx(pp.setIntermediaryRToken, "setIntermediaryRToken")(rToken.address,  { from: admin });
+        //test that rToken is the intermediary
+        assert.equal(await pp.isIntermediaryRToken.call(), true);
+        //test that correct exchange is set
+        assert.equal(await pp.intermediaryTokenExchange.call(), underlyingTokenExchange.address);
+
+        //deposit ether
+        let tx = await web3tx(pp.depositEther, "depositEther", {
+            inLogs: [{
+                name: "EtherDepositReceived",
+                args: {
+                    orderId: "1",
+                    depositor: customer1,
+                    amount: web3.utils.toWei("0.1", "ether"),
+                    intermediaryToken: rToken.address
+                }
+            }]
+        })(1, { value: web3.utils.toWei("0.1", "ether"), from: customer1 });
+
+        //test that payment processor has rTokens
+        assert.equal((await rToken.balanceOf.call(pp.address)).toString(), "908");
+
+        //redeem rTokens and transfer to account
+        let balanceBefore = new web3.utils.BN(await underlyingToken.balanceOf.call(admin));
+        tx = await web3tx(pp.withdrawToken, "redeem rTokens to owner", {
+            inLogs: [{
+                name: "TokenDepositWithdrawn",
+                args: {
+                    token: underlyingToken.address,
+                    to: admin,
+                    amount: "908"
+                }
+            }]
+        })(underlyingToken.address, 908, admin, { from: admin });
+        let balanceAfter = new web3.utils.BN(await underlyingToken.balanceOf.call(admin));
+        assert.equal((await balanceAfter.sub(balanceBefore)).toString(), "908");
+    });
+
+    it("deposit token and redeem rToken", async () => {
+        //create exchange for the underlying token
+        await web3tx(uniswapFactory.createExchange, "uniswapFactory.createExchange")(underlyingToken.address, { from: admin });
+        const underlyingTokenExchangeAddress = await uniswapFactory.getExchange.call(underlyingToken.address);
+        console.log("exchange for inputToken created at: ", underlyingTokenExchangeAddress);
+        const underlyingTokenExchange = await UniswapExchange.at(underlyingTokenExchangeAddress);
+        await web3tx(underlyingToken.mint, "underlying token mint 1000 tokens")(admin, 1000, { from: admin });
+        await web3tx(underlyingToken.approve, "underlying token approve exchange 1000 tokens")(
+            underlyingTokenExchangeAddress,
+            1000,
+            { from: admin });
+        await web3tx(underlyingTokenExchange.addLiquidity, "underlyingTokenExchange.addLiquidity 0.01 ETH <-> 1000 tokens")(
+            0,
+            1000,
+            MAX_DEADLINE,
+            { from: admin, value: web3.utils.toWei("0.01", "ether") });
+        // 1 x underlying token = 0.01 / 1000 ~= 0.00001 ~= 0.0000099 ETH
+        assert.isTrue(web3.utils.fromWei(await underlyingTokenExchange.getTokenToEthInputPrice.call(1), "ether").startsWith("0.0000099"));
+
+        //Create another token and exchange
+        const otherToken = await web3tx(ERC20Mintable.new, "ERC20Mintable.new")({ from: admin});
+        await web3tx(uniswapFactory.createExchange, "uniswapFactory.createExchange")(otherToken.address, { from: admin });
+        const otherTokenExchangeAddress = await uniswapFactory.getExchange.call(otherToken.address);
+        console.log("exchange for otherToken created at: ", otherTokenExchangeAddress);
+        const otherTokenExchange = await UniswapExchange.at(otherTokenExchangeAddress);
+        await web3tx(otherToken.mint, "otherToken mint 1000 tokens")(admin, 1000, { from: admin });
+        await web3tx(otherToken.approve, "otherToken approve exchange 1000 tokens")(
+            otherTokenExchangeAddress,
+            1000,
+            { from: admin });
+        await web3tx(otherTokenExchange.addLiquidity, "otherTokenExchange.addLiquidity 0.01 ETH <-> 1000 tokens")(
+            0,
+            1000,
+            MAX_DEADLINE,
+            { from: admin, value: web3.utils.toWei("0.01", "ether") });
+        // 1 x TOKEN A = 0.01 / 1000 ~= 0.00001 ~= 0.0000099 ETH
+        assert.isTrue(web3.utils.fromWei(await otherTokenExchange.getTokenToEthInputPrice.call(1), "ether").startsWith("0.0000099"));
+
+
+        //set RToken as the intermediary token
+        await web3tx(pp.setIntermediaryRToken, "setIntermediaryRToken")(rToken.address,  { from: admin });
+        //test that rToken is the intermediary
+        assert.equal(await pp.isIntermediaryRToken.call(), true);
+        //test that correct exchange is set
+        assert.equal(await pp.intermediaryTokenExchange.call(), underlyingTokenExchange.address);
+
+
+        // deposit underlying token
+        await web3tx(underlyingToken.mint, "underlyingToken mint 100 tokens to customer2")(customer2, toWad(100), { from: admin });
+        await web3tx(underlyingToken.approve, "underlyingToken approve pp 10 tokens by customer2")(
+            pp.address,
+            100,
+            { from: customer2 });
+        await web3tx(pp.depositToken, "depositToken", {
+            inLogs: [{
+                name: "TokenDepositReceived",
+                args: {
+                    orderId: "1",
+                    depositor: customer2,
+                    inputToken: underlyingToken.address,
+                    amount: "100",
+                    intermediaryToken: rToken.address,
+                    // amountBought: "0" - we do not test the value
+                }
+            }]
+        })(1, customer2, underlyingToken.address, 100, { from: depositAgent });
+        console.log("rTokens: " + (await rToken.balanceOf.call(pp.address)).toString());
+        assert.equal((await rToken.balanceOf.call(pp.address)).toString(), "100");
+
+        //deposit a different token from the underlying token
+        await web3tx(otherToken.mint, "otherToken mint 10 tokens to customer2")(customer2, 10, { from: admin });
+        await web3tx(otherToken.approve, "otherToken approve pp 10 tokens by customer2")(
+            pp.address,
+            10,
+            { from: customer2 });
+        await web3tx(pp.depositToken, "depositToken", {
+            inLogs: [{
+                name: "TokenDepositReceived",
+                args: {
+                    orderId: "1",
+                    depositor: customer2,
+                    inputToken: otherToken.address,
+                    amount: "10",
+                    intermediaryToken: rToken.address,
+                    // amountBought: "0" - we do not test the value
+                }
+            }]
+        })(1, customer2, otherToken.address, 10, { from: depositAgent });
+        console.log("rTokens: " + (await rToken.balanceOf.call(pp.address)).toString());
+        assert.equal((await rToken.balanceOf.call(pp.address)).toString(), "109");
+
+        //redeem rTokens and transfer to account
+        let balanceBefore = new web3.utils.BN(await underlyingToken.balanceOf.call(admin));
+        let tx = await web3tx(pp.withdrawToken, "redeem rTokens to owner", {
+            inLogs: [{
+                name: "TokenDepositWithdrawn",
+                args: {
+                    token: underlyingToken.address,
+                    to: admin,
+                    amount: "109"
+                }
+            }]
+        })(underlyingToken.address, 109, admin, { from: admin });
+        let balanceAfter = new web3.utils.BN(await underlyingToken.balanceOf.call(admin));
+        assert.equal((await balanceAfter.sub(balanceBefore)).toString(), "109");
     });
 });

--- a/test/PaymentProcessor.test.js
+++ b/test/PaymentProcessor.test.js
@@ -1,7 +1,7 @@
 const PaymentProcessor = artifacts.require("PaymentProcessor");
 const ERC20Mintable = artifacts.require("ERC20Mintable");
 const { UniswapFactory, UniswapExchange } = require("../uniswap");
-const { expectRevert } = require("openzeppelin-test-helpers");
+const { expectRevert } = require("@openzeppelin/test-helpers");
 const { web3tx, toWad } = require("@decentral.ee/web3-test-helpers");
 
 const ComptrollerMock = artifacts.require("ComptrollerMock");
@@ -26,11 +26,9 @@ contract("PaymentProcessor", accounts => {
 
     //rToken variables
     let underlyingToken;
-    let cToken;
     let compoundAS;
     let rToken;
     let rTokenLogic;
-    let SELF_HAT_ID;
 
     async function createCompoundAllocationStrategy(cTokenExchangeRate) {
         const comptroller = await web3tx(ComptrollerMock.new, "ComptrollerMock.new")({ from: admin });
@@ -83,7 +81,6 @@ contract("PaymentProcessor", accounts => {
         await web3tx(underlyingToken.mint, "token.mint 1000 -> customer1")(customer1, toWad(1000), { from: admin });
 
         const result = await createCompoundAllocationStrategy(toWad(.1));
-        cToken = result.cToken;
         compoundAS = result.compoundAS;
 
         // Deploy the rToken logic/library contract
@@ -107,7 +104,6 @@ contract("PaymentProcessor", accounts => {
         rToken = await RToken.at(proxy.address);
 
         await web3tx(compoundAS.transferOwnership, "compoundAS.transferOwnership")(rToken.address);
-        SELF_HAT_ID = await rToken.SELF_HAT_ID.call();
     });
 
     it("deposit and withdraw ether", async () => {
@@ -303,7 +299,7 @@ contract("PaymentProcessor", accounts => {
         assert.equal(await pp.intermediaryTokenExchange.call(), underlyingTokenExchange.address);
 
         //deposit ether
-        let tx = await web3tx(pp.depositEther, "depositEther", {
+        await web3tx(pp.depositEther, "depositEther", {
             inLogs: [{
                 name: "EtherDepositReceived",
                 args: {
@@ -320,7 +316,7 @@ contract("PaymentProcessor", accounts => {
 
         //redeem rTokens and transfer to account
         let balanceBefore = new web3.utils.BN(await underlyingToken.balanceOf.call(admin));
-        tx = await web3tx(pp.withdrawToken, "redeem rTokens to owner", {
+        await web3tx(pp.withdrawToken, "redeem rTokens to owner", {
             inLogs: [{
                 name: "TokenDepositWithdrawn",
                 args: {
@@ -427,7 +423,7 @@ contract("PaymentProcessor", accounts => {
 
         //redeem rTokens and transfer to account
         let balanceBefore = new web3.utils.BN(await underlyingToken.balanceOf.call(admin));
-        let tx = await web3tx(pp.withdrawToken, "redeem rTokens to owner", {
+        await web3tx(pp.withdrawToken, "redeem rTokens to owner", {
             inLogs: [{
                 name: "TokenDepositWithdrawn",
                 args: {

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -18,4 +18,25 @@
  *
  */
 
-module.exports = require("@EtherPhoneBooth/config")().truffle;
+//module.exports = require("@EtherPhoneBooth/config")().truffle;
+
+module.exports = {
+  networks: {
+    development: {
+      host: "127.0.0.1",
+      port: 7545,
+      network_id: "*" // Match any network id
+    },
+  },
+  compilers: {
+    solc: {
+      version: "0.5.10",
+      settings: {
+        optimizer: {
+          enabled: true,
+          runs: 200
+        }
+      }
+    }
+  }
+};

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -21,22 +21,15 @@
 //module.exports = require("@EtherPhoneBooth/config")().truffle;
 
 module.exports = {
-  networks: {
-    development: {
-      host: "127.0.0.1",
-      port: 7545,
-      network_id: "*" // Match any network id
-    },
-  },
-  compilers: {
-    solc: {
-      version: "0.5.10",
-      settings: {
-        optimizer: {
-          enabled: true,
-          runs: 200
+    compilers: {
+        solc: {
+            version: "0.5.10",
+            settings: {
+                optimizer: {
+                    enabled: true,
+                    runs: 200
+                }
+            }
         }
-      }
     }
-  }
 };


### PR DESCRIPTION
Adds support for storing deposits in rTokens.
In order to use the functionality, the owner must set the rToken as the the intermediary token using the `setIntermediaryRToken()` method.
When Ether is deposited, it is used to buy the intermediary rToken's underlying tokens and these tokens are then traded for rTokens.
When a token is deposited, a similar process takes place (unless the deposited token is the underlying token)

In addition, the previous private `truffle-config.js` is replaced and a development network configuration is added.